### PR TITLE
Add blog post on payment transparency to share page

### DIFF
--- a/share.html
+++ b/share.html
@@ -204,7 +204,8 @@
               </div>
               <div id="collapse-8-1" class="panel-collapse collapse" role="tabpanel" aria-labelledby="faq-8-1">
                 <div class="panel-body">
-                  <p>Storj Share payments are made once a month. So if you start farming right now, you will not receive a payment until early next month. We can't run the payment script until the month ends, then it needs to be reviewed by the community, and then rewards are finally paid out. We will make make this process faster and more transparent in the interface in the future.</p>
+                  <p>Storj Share payments are made once a month. So if you start farming right now, you will not receive a payment until early next month. We can't run the payment script until the month ends, then it needs to be reviewed by the community, and then rewards are finally paid out. We will make make this process faster and more transparent in the interface in the future.
+                    Specifics on the math behind payment calculations can be found <a href= "http://blog.storj.io/post/156584576553/storj-payout-transparency" target="_blank" class="link">here</a>.</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
We recently published the formula for payment calculations and should be linked to on this page. 