### PR TITLE
Update SJCX Asset Information link

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -422,7 +422,7 @@
 			    </div>
 			    <div id="collapse-6-4" class="panel-collapse collapse" role="tabpanel" aria-labelledby="faq-6-4">
 			      <div class="panel-body">
-			        <p>There will ever only be 500 million SJCX; no more can be created. SJCX is a locked asset on the Counterparty protocol, more info can be found <a href="http://blockscan.com/assetInfo/SJCX">here</a>.</p>
+			        <p>There will ever only be 500 million SJCX; no more can be created. SJCX is a locked asset on the Counterparty protocol, more info can be found <a href="https://counterpartychain.io/asset/SJCX">here</a>.</p>
 			      </div>
 			    </div>
 			  </div>


### PR DESCRIPTION
Blockscan.com has been discontinued. Changing asset information link to counterpartychain.io.