### PR TITLE
Remove important flag for styling tables

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1588,7 +1588,7 @@ tr {
     transition: all 0.15s ease-in-out;
 }
 th, td {
-	padding: 1.8em !important;
+	padding: 1.8em;
 }
 
 .table>thead>tr>th {


### PR DESCRIPTION
In preparation for the new StorjShare Dashboard the flag needs to be removed.
Besides that there is not a single table on the current website anyway, so we can adjust this without any affects to the current live version