### PR TITLE
V3 Alpha Testing link is broken on community page

### DIFF
--- a/community.html
+++ b/community.html
@@ -185,7 +185,7 @@
                   <h2 style="color:black;">V3 Alpha Testing</h2>
                   <p style="color: rgba(0,0,0,0.8);">Run a local test network on your infrastructure.</p>
                   <div class="spacer10"></div>
-                  <a href="https://github.com/storj/docs/blob/master/test-network.md" class="btn btn-block">Learn More</a>
+                  <a href="https://github.com/storj/docs/blob/master/Test-network.md" class="btn btn-block">Learn More</a>
                 </div>
               </div>
         <div class="col-xs-12 col-sm-12 col-md-4">


### PR DESCRIPTION
Looks like https://github.com/storj/docs/commit/ed1b2b19829bb767c7625d8ca15c4260f9f68eba renamed a few of the files under storj/docs/ on Dec 29.

`https://github.com/storj/docs/blob/master/test-network.md` no longer exists, and was replaced with `https://github.com/storj/docs/blob/master/Test-network.md`