### PR TITLE
adding google analytics

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,3 +1,13 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-152935169-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-152935169-1');
+</script>
+
 <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
from google: "This is the Global Site Tag (gtag.js) tracking code for this property. Copy and paste this code as the first item into the <HEAD> of every webpage you want to track. If you already have a Global Site Tag on your page, simply add the config line from the snippet below to your existing Global Site Tag." 

"The Global Site Tag provides streamlined tagging across Google’s site measurement, conversion tracking, and remarketing products – giving you better control while making implementation easier. By using gtag.js, you will be able to benefit from the latest dynamic features and integrations as they become available. Learn more"

I am adding it here because from what I can gather every page on storj.io references this head file. I am not sure if the blog also uses this one.