### PR TITLE
add /clone endpoint for storj-clone

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,9 @@
   to = "https://thirsty-austin-89166b.netlify.com/:splat"
   status = 200
   force = true
+
+[[redirects]]
+  from = "/clone"
+  to = "https://gist.githubusercontent.com/zeebo/ecc0abd0aec09c9eff85b12d788dfc81/raw/storj-clone"
+  status = 302
+  force = true


### PR DESCRIPTION
This makes storj-clone as easy as `curl storj.io/clone | sh -s <repo>`.