### PR TITLE
netlify: Add some good security headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,9 @@
   to = "https://gist.githubusercontent.com/zeebo/ecc0abd0aec09c9eff85b12d788dfc81/raw/storj-clone"
   status = 302
   force = true
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "deny"
+    Strict-Transport-Security = "max-age=300; includeSubDomains"


### PR DESCRIPTION
Add a couple of headers to be served with all the pages of the site for
denying to load the site in an iframe and to indicate to the browser
that the site has always to be accessed through HTTPS.