### PR TITLE
netlify: Restore removed security headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,3 +15,9 @@
   to = "https://storj.io/blog/2019/01/sharing-storage-space-for-fun-and-profit/"
   status = 301
   force = true
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "deny"
+    Strict-Transport-Security = "max-age=300; includeSubDomains"


### PR DESCRIPTION
Some headers were added to mitigate some security attacks but they got
removed involuntary in a subsequent commit.

This commit restore them back.