### PR TITLE
Create Community approved  Satellite list

### DIFF
--- a/static/trusted-satellites
+++ b/static/trusted-satellites
@@ -1,0 +1,1 @@
+118UWpMCHzs6CvSgWd9BfFVjw5K9pZbJjkfZJexMtSkmKxvvAW@satellite.stefan-benten.de:7777


### PR DESCRIPTION
With this list hosted under storj.io/trusted-satellites we can start an officially approved list of community run satellites.
This is one of the foundational aspects to get my satellite back onto the network.

I have the corresponding changes ready for the storagenode side to add it in, but this is a prerequiste to go ahead.